### PR TITLE
güncelle: .gitignore

### DIFF
--- a/server/.gitignore
+++ b/server/.gitignore
@@ -1,1 +1,21 @@
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Ignore pattern
+__*
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# DotEnv formatted file
 .env
+
+# Dependency directories (remove the comment below to include it)
+# vendor/


### PR DESCRIPTION
Bu PR `.gitignore` dosyasına bazı yaygın içerikleri ekler.

Ek olarak projede yer olarak çalışıldığında Git tarafından algılanması istenmeyen dosyalar oluşturmak amacıyla `__*` deseni eklenmiştir. Eğer projede sorun çıkarabilecek kritik dosyalar bu desene uyuyorsa lütfen buna dikkat edin.